### PR TITLE
Fix scroll listener reattachment

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,20 +7,20 @@ interface HeaderProps {
   toggleTheme: () => void;
 }
 
+const navLinks = [
+  { name: 'Início', href: '#hero' },
+  { name: 'Serviços', href: '#benefits' },
+  { name: 'Sobre', href: '#about' },
+  { name: 'Trabalhos', href: '#portfolio' },
+  { name: 'Contato', href: '#contact' },
+];
+
 const Header: React.FC<HeaderProps> = ({ theme, toggleTheme }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const [activeSection, setActiveSection] = useState('hero');
   const headerRef = useRef<HTMLElement>(null);
   const navRef = useRef<HTMLDivElement>(null);
-
-  const navLinks = [
-    { name: 'Início', href: '#hero' },
-    { name: 'Serviços', href: '#benefits' },
-    { name: 'Sobre', href: '#about' },
-    { name: 'Trabalhos', href: '#portfolio' },
-    { name: 'Contato', href: '#contact' },
-  ];
 
   useEffect(() => {
     const handleScroll = () => {
@@ -42,7 +42,7 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme }) => {
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [navLinks]);
+  }, []);
 
   useEffect(() => {
     document.body.style.overflow = isOpen ? 'hidden' : '';


### PR DESCRIPTION
## Summary
- avoid recreating scroll listener on every render by moving `navLinks` outside the component and removing it from `useEffect` deps

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840d9e4d59c8331b4862e1c8fa75365