### PR TITLE
Remove unused generate-code-map2.js entry

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "generate-code-map2.js"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- remove obsolete `generate-code-map2.js` entry from `tsconfig.app.json`

## Testing
- `npm run lint` *(fails: 2 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840db3a40dc8331bc1c6447cb2e4f8f