### PR TITLE
Add credibility badge in hero section

### DIFF
--- a/public/credibility.svg
+++ b/public/credibility.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.8">
+  <circle cx="12" cy="12" r="11" fill="none" />
+  <path d="m11 17 2 2a1 1 0 1 0 3-3" />
+  <path d="m14 14 2.5 2.5a1 1 0 1 0 3-3l-3.88-3.88a3 3 0 0 0-4.24 0l-.88.88a1 1 0 1 1-3-3l2.81-2.81a5.79 5.79 0 0 1 7.06-.87l.47.28a2 2 0 0 0 1.42.25L21 4" />
+  <path d="m21 3 1 11h-2" />
+  <path d="M3 3 2 14l6.5 6.5a1 1 0 1 0 3-3" />
+  <path d="M3 4h8" />
+</svg>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -131,6 +131,13 @@ const Hero: React.FC = () => {
         <div className="absolute inset-0 bg-gradient-to-b from-[var(--color-primary)]/90 via-[var(--color-primary)]/80 to-[var(--color-primary)]/70"></div>
       </div>
 
+      {/* Badge de credibilidade */}
+      <img
+        src="/credibility.svg"
+        alt="Selo de credibilidade"
+        className="absolute top-6 right-6 w-20 z-5 opacity-60 pointer-events-none"
+      />
+
       <div ref={contentRef} className="relative z-10 container mx-auto px-4 sm:px-6 lg:px-8 py-12 md:py-0">
         <div className="flex flex-col lg:flex-row items-center justify-between gap-10 lg:gap-16">
           <div className="w-full lg:w-1/2 max-w-xl">


### PR DESCRIPTION
## Summary
- add a new semi-transparent credibility badge image
- overlay credibility badge in hero section

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6840dd3bde3c8331af9b00d5933ace4a